### PR TITLE
fix MYNT3D pro amazon link

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -245,7 +245,7 @@ const pens = ref([
     power: { short: "Plug-in", full: "Plug-in" },
     filament: { short: "ABS/PLA", full: "ABS, PLA" },
     price: "$59.99",
-    buyLink: "https://amzn.to/3Ry7avz"
+    buyLink: "https://amzn.to/43YOZXy"
   },
   {
     name: "MYNT3D Super",


### PR DESCRIPTION
Wan-Lin
  7:16 AM
replied to a thread:
@shoushan Column 2 的 MYNT3D Pro 下面的 Amazon button 會連到下面這個 "3Doodler Start+" 好像是重複的？…
麻煩改成這個連結：
https://amzn.to/43YOZXy