### PR TITLE
seo: add www redirect, canonical slash fix, sitemap

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -25,7 +25,7 @@ export default defineNuxtConfig({
       ],
       link: [
         { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
-        { rel: 'canonical', href: 'https://enkiatelier.com' },
+        { rel: 'canonical', href: 'https://enkiatelier.com/' },
         { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
         { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' },
         { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Lora:wght@400;600;700&family=DM+Sans:wght@300;400;500&display=swap' }

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://enkiatelier.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "www.enkiatelier.com" }],
+      "destination": "https://enkiatelier.com/:path*",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
- vercel.json: 301 redirect www.enkiatelier.com → enkiatelier.com
- nuxt.config.ts: update canonical href to include trailing slash
- public/sitemap.xml: add static sitemap with canonical https non-www URL