### PR TITLE
seo: technical SEO foundation

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,18 @@
+# HTTP → HTTPS (bare domain)
+[[redirects]]
+  from = "http://enkiatelier.com/*"
+  to   = "https://enkiatelier.com/:splat"
+  status = 301
+  force  = true
+
+# www → non-www (HTTPS)
 [[redirects]]
   from = "https://www.enkiatelier.com/*"
   to   = "https://enkiatelier.com/:splat"
   status = 301
   force  = true
 
+# www → non-www (HTTP, catches both issues at once)
 [[redirects]]
   from = "http://www.enkiatelier.com/*"
   to   = "https://enkiatelier.com/:splat"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -51,11 +51,21 @@ export default defineNuxtConfig({
             "@context": "https://schema.org",
             "@graph": [
               {
+                "@type": "WebSite",
+                "name": "Enki Atelier",
+                "url": "https://enkiatelier.com",
+                "potentialAction": {
+                  "@type": "SearchAction",
+                  "target": "https://enkiatelier.com/?q={search_term_string}",
+                  "query-input": "required name=search_term_string"
+                }
+              },
+              {
                 "@type": "Organization",
                 "name": "Enki Atelier",
                 "url": "https://enkiatelier.com",
                 "logo": "https://enkiatelier.com/logo.png",
-                "description": "PhD-designed STEAM kits for kids ages 6–12. Hands-on engineering and physics activities using 3D pens.",
+                "description": "PhD-designed 3D pen STEAM kits for kids ages 6–12. Hands-on engineering and physics activities.",
                 "sameAs": [
                   "https://www.instagram.com/enkiatelier",
                   "https://www.facebook.com/enkiatelier",

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -174,6 +174,7 @@ import { ref, onMounted, onUnmounted } from 'vue'
 
 useHead({
   title: 'From the Studio — Enki Atelier Blog',
+  link: [{ rel: 'canonical', href: 'https://enkiatelier.com/blog' }],
   meta: [
     { name: 'description', content: '3D pen tips, project stories, and ideas for curious kids and adults. From the Enki Atelier studio.' }
   ]

--- a/pages/blog/posts/he-designed-his-own-marble-run-it-started-as-a-cardboard-box.vue
+++ b/pages/blog/posts/he-designed-his-own-marble-run-it-started-as-a-cardboard-box.vue
@@ -202,9 +202,24 @@ import { ref, onMounted, onUnmounted } from 'vue'
 
 useHead({
   title: 'He Designed His Own Marble Run. It Started as a Cardboard Box. — Enki Atelier',
+  link: [{ rel: 'canonical', href: 'https://enkiatelier.com/blog/posts/he-designed-his-own-marble-run-it-started-as-a-cardboard-box' }],
   meta: [
     { name: 'description', content: 'A mom on childhood toys made from string and bamboo, a marble run built from cardboard, and what Earth Day is really asking us to notice.' }
-  ]
+  ],
+  script: [{
+    type: 'application/ld+json',
+    innerHTML: JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      "headline": "He Designed His Own Marble Run. It Started as a Cardboard Box.",
+      "datePublished": "2026-04-17",
+      "author": { "@type": "Organization", "name": "Enki Atelier", "url": "https://enkiatelier.com" },
+      "publisher": { "@type": "Organization", "name": "Enki Atelier", "logo": { "@type": "ImageObject", "url": "https://enkiatelier.com/logo.png" } },
+      "url": "https://enkiatelier.com/blog/posts/he-designed-his-own-marble-run-it-started-as-a-cardboard-box",
+      "description": "A mom on childhood toys made from string and bamboo, a marble run built from cardboard, and what Earth Day is really asking us to notice.",
+      "image": "https://enkiatelier.com/blog/2026-04-17-marble-run-01.png"
+    })
+  }]
 })
 
 const mobileMenuOpen = ref(false)

--- a/pages/blog/posts/he-noticed-she-loved-flowers-he-made-her-one.vue
+++ b/pages/blog/posts/he-noticed-she-loved-flowers-he-made-her-one.vue
@@ -214,9 +214,24 @@ import { ref, onMounted, onUnmounted } from 'vue'
 
 useHead({
   title: 'He Noticed She Loved Flowers. He Made Her One. — Enki Atelier',
+  link: [{ rel: 'canonical', href: 'https://enkiatelier.com/blog/posts/he-noticed-she-loved-flowers-he-made-her-one' }],
   meta: [
     { name: 'description', content: 'My son wanted to make his teacher a desert snake with his 3D pen. Then a cactus. Then a car. Then flowers. A Teacher Appreciation Week story.' }
-  ]
+  ],
+  script: [{
+    type: 'application/ld+json',
+    innerHTML: JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      "headline": "He Noticed She Loved Flowers. He Made Her One.",
+      "datePublished": "2026-05-05",
+      "author": { "@type": "Organization", "name": "Enki Atelier", "url": "https://enkiatelier.com" },
+      "publisher": { "@type": "Organization", "name": "Enki Atelier", "logo": { "@type": "ImageObject", "url": "https://enkiatelier.com/logo.png" } },
+      "url": "https://enkiatelier.com/blog/posts/he-noticed-she-loved-flowers-he-made-her-one",
+      "description": "My son wanted to make his teacher a desert snake with his 3D pen. Then a cactus. Then a car. Then flowers.",
+      "image": "https://enkiatelier.com/blog/2026-05-05-flowers-finished-01.png"
+    })
+  }]
 })
 
 const mobileMenuOpen = ref(false)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://enkiatelier.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,8 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+  <!-- Homepage -->
   <url>
     <loc>https://enkiatelier.com/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+
+  <!-- Blog listing -->
+  <url>
+    <loc>https://enkiatelier.com/blog</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <!-- Blog posts -->
+  <url>
+    <loc>https://enkiatelier.com/blog/posts/he-noticed-she-loved-flowers-he-made-her-one</loc>
+    <lastmod>2026-05-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://enkiatelier.com/blog/posts/why-some-kids-need-to-make-something-first</loc>
+    <lastmod>2026-05-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://enkiatelier.com/blog/posts/he-designed-his-own-marble-run-it-started-as-a-cardboard-box</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
 </urlset>


### PR DESCRIPTION
P0 — robots, sitemap, HTTPS:
- public/robots.txt: created (Allow: /, Sitemap reference)
- public/sitemap.xml: expanded with blog listing + 3 blog posts
- netlify.toml: added http://enkiatelier.com/* → 301 HTTPS redirect

P1 — canonical, structured data:
- blog/index.vue: canonical https://enkiatelier.com/blog
- flower post: canonical + BlogPosting JSON-LD schema
- marble run post: canonical + BlogPosting JSON-LD schema
- nuxt.config.ts: added WebSite schema with SearchAction

P2 — hreflang: not implemented (English only)